### PR TITLE
Fix issue related to archiver package upgrade

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -311,7 +311,7 @@ func createUpdate(updateDirectoryPath, distributionPath string) {
 	targetDirectory = strings.Replace(targetDirectory, "/", constant.PATH_SEPARATOR, -1)
 
 	logger.Debug(fmt.Sprintf("targetDirectory: %s", targetDirectory))
-	err = archiver.Zip(updateZipName, []string{targetDirectory})
+	err = archiver.Zip.Make(updateZipName, []string{targetDirectory})
 	util.HandleErrorAndExit(err)
 
 	// Remove the temp directories


### PR DESCRIPTION
This commit changes the archiver package usage. This is done to fix
'cannot call non-function archiver.Zip' issue which occurs due to
recent code changes in the archiver package.

Resolves #2