### PR TITLE
Adapt Glide as the dependency management tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ _testmain.go
 /build/
 /.idea/
 *.iml
+
+vendor/

--- a/build.sh
+++ b/build.sh
@@ -3,6 +3,11 @@
 target="wum-uc.go"
 version="1.0.0"
 
+type glide >/dev/null 2>&1 || { echo >&2 "Glide dependency management is needed to build the Update Creator Tool (https://glide.sh/).  Aborting."; exit 1; }
+
+echo "Setting up dependencies..."
+glide install
+
 platforms="darwin/amd64/macosx/x64 linux/386/linux/i586 linux/amd64/linux/x64 windows/386/windows/i586 windows/amd64/windows/x64"
 
 for platform in ${platforms}

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,101 @@
+hash: 69248e39eb355716de38b8845f246900bc7cfc8d0f71485b95623bd99e2949aa
+updated: 2016-12-01T10:39:27.351061233+05:30
+imports:
+- name: github.com/dsnet/compress
+  version: b9aab3c6a04eef14c56384b4ad065e7b73438862
+  subpackages:
+  - bzip2
+  - bzip2/internal/sais
+  - internal
+  - internal/prefix
+- name: github.com/fatih/color
+  version: dea9d3a26a087187530244679c1cfb3a42937794
+- name: github.com/fsnotify/fsnotify
+  version: fd9ec7deca8bf46ecd2a795baaacf2b3a9be1197
+- name: github.com/hashicorp/hcl
+  version: 5550aaba7896ad2a161888b40954bc0f0787bb81
+  subpackages:
+  - hcl/ast
+  - hcl/parser
+  - hcl/scanner
+  - hcl/strconv
+  - hcl/token
+  - json/parser
+  - json/scanner
+  - json/token
+- name: github.com/ian-kent/go-log
+  version: 5731446c36ab9f716106ce0731f484c50fdf1ad1
+  subpackages:
+  - appenders
+  - layout
+  - levels
+  - log
+  - logger
+- name: github.com/inconshreveable/mousetrap
+  version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/magiconair/properties
+  version: 9c47895dc1ce54302908ab8a43385d1f5df2c11c
+- name: github.com/mattn/go-colorable
+  version: d228849504861217f796da67fae4f6e347643f15
+- name: github.com/mattn/go-isatty
+  version: 30a891c33c7cde7b02a981314b4228ec99380cca
+- name: github.com/mattn/go-runewidth
+  version: 737072b4e32b7a5018b4a7125da8d12de90e8045
+- name: github.com/mholt/archiver
+  version: cdc68dd1f170b8dfc1a0d2231b5bb0967ed67006
+- name: github.com/mitchellh/mapstructure
+  version: f3009df150dadf309fdee4a54ed65c124afad715
+- name: github.com/nwaples/rardecode
+  version: f94841372ddc36be531a5c3e1206238e32e93d74
+- name: github.com/olekukonko/tablewriter
+  version: bdcc175572fd7abece6c831e643891b9331bc9e7
+- name: github.com/pelletier/go-buffruneio
+  version: df1e16fde7fc330a0ca68167c23bf7ed6ac31d6d
+- name: github.com/pelletier/go-toml
+  version: 7cb988051d5045890cb91402a0b5fddc76c627bc
+- name: github.com/philhofer/fwd
+  version: 98c11a7a6ec829d672b03833c3d69a7fae1ca972
+- name: github.com/pkg/errors
+  version: 645ef00459ed84a119197bfb8d8205042c6df63d
+- name: github.com/renstrom/dedent
+  version: a1eba44eaecc89804e4b05ce2d17168eb353d524
+- name: github.com/spf13/afero
+  version: 06b7e5f50606ecd49148a01a6008942d9b669217
+  subpackages:
+  - mem
+- name: github.com/spf13/cast
+  version: 24b6558033ffe202bf42f0f3b870dcc798dd2ba8
+- name: github.com/spf13/cobra
+  version: 9495bc009a56819bdb0ddbc1a373e29c140bc674
+- name: github.com/spf13/jwalterweatherman
+  version: 33c24e77fb80341fe7130ee7c594256ff08ccc46
+- name: github.com/spf13/pflag
+  version: 5ccb023bc27df288a957c5e994cd44fd19619465
+- name: github.com/spf13/viper
+  version: 651d9d916abc3c3d6a91a12549495caba5edffd2
+- name: github.com/t-k/fluent-logger-golang
+  version: 0f8ec08f2057a61574b6943e75045fffbeae894e
+  subpackages:
+  - fluent
+- name: github.com/tinylib/msgp
+  version: ad0ff2e232ad2e37faf67087fb24bf8d04a8ce20
+  subpackages:
+  - msgp
+- name: github.com/ulikunitz/xz
+  version: 3e84f9193f6ec5cd5998463d64c88f798356b0c9
+  subpackages:
+  - internal/hash
+  - internal/xlog
+  - lzma
+- name: golang.org/x/sys
+  version: d5645953809d8b4752afb2c3224b1f1ad73dfa70
+  subpackages:
+  - unix
+- name: golang.org/x/text
+  version: 5c6cf4f9a2357d38515014cea8c488ed22bdab90
+  subpackages:
+  - transform
+  - unicode/norm
+- name: gopkg.in/yaml.v2
+  version: a5b47d31c556af34a302ce5d659e6fea44d90de0
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,19 @@
+package: .
+import:
+- package: github.com/fatih/color
+  version: ~1.1.0
+- package: github.com/ian-kent/go-log
+  subpackages:
+  - layout
+  - levels
+  - log
+- package: github.com/mholt/archiver
+  version: ~2.0.0
+- package: github.com/olekukonko/tablewriter
+- package: github.com/pkg/errors
+  version: ~0.8.0
+- package: github.com/renstrom/dedent
+  version: ~1.0.0
+- package: github.com/spf13/cobra
+- package: github.com/spf13/viper
+- package: gopkg.in/yaml.v2


### PR DESCRIPTION
This PR includes the following meta files required by the Glide dependency management tool.

1. `glide.yaml` - This file contains the list of the dependencies required by the Update Creator Tool and their specific versions
2. `glide.lock` - This file contains the VCS revision IDs for each of the dependencies that should be present in the vendor folder.

Additionally, this PR contains the changes needed in the `build.sh` script to run `glide install` command, which populates the `vendor/` folder with the needed dependencies at their versions, before the actual cross compilation happens. If Glide is not found on the system, the `build.sh` script will show an error and exit with status `1`.

The `vendor/` folder itself is not committed to VCS as there is no need to do so. The `glide.lock` file takes care of storing the state of the dependencies. Any first time user doesn't have to perform any additional tasks, other than installing Glide on their system, since the `build.sh` script will populate the `vendor/` folder. 

This resolves #4 