### PR TITLE
Add EULA LICENSE.txt to update location

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -195,9 +195,13 @@ func initDirectory(destination string) {
 		absDestination))
 
 	// Check if LICENSE.txt already exists
-	licenseSource, err := filepath.Abs(filepath.Dir(os.Args[0]))
+	licenseSource, err := os.Getwd()
 	if err != nil {
 		util.HandleErrorAndExit(err, "Couldn't get current working directory.")
+	}
+
+	if strings.HasSuffix(licenseSource, "bin") {
+		licenseSource = licenseSource[0:len(licenseSource)-len("bin")]
 	}
 
 	licenseSource = filepath.Join(licenseSource, "resources", constant.LICENSE_FILE)
@@ -230,6 +234,10 @@ func initDirectory(destination string) {
 		} else {
 			util.PrintInfo("Existing license is WSO2 Update EULA 1.0. This will be used as is.")
 		}
+	} else {
+		// Write/overwrite LICENSE.txt
+		util.CopyFile(licenseSource, licenseDest)
+		util.PrintInfo(fmt.Sprintf("WSO2 Update EULA 1.0 copied to %v", licenseDest))
 	}
 
 	//Print whats next

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -194,6 +194,44 @@ func initDirectory(destination string) {
 	util.PrintInfo(fmt.Sprintf("'%s' has been successfully created at '%s'.", constant.UPDATE_DESCRIPTOR_FILE,
 		absDestination))
 
+	// Check if LICENSE.txt already exists
+	licenseSource, err := os.Getwd()
+	if err != nil {
+		util.HandleErrorAndExit(err, "Couldn't get current working directory.")
+	}
+
+	licenseSource = filepath.Join(licenseSource, "resources", constant.LICENSE_FILE)
+	licenseDest := filepath.Join(destination, constant.LICENSE_FILE)
+	_, err = os.Stat(licenseDest)
+	if err == nil {
+		util.PrintInfo("An existing LICENSE.txt file found")
+		// Text compare for EULA
+		destTxtB, err := ioutil.ReadFile(licenseDest)
+		if err != nil {
+			util.PrintInfo("Couldn't read the existing LICENSE.txt file. ")
+			// Delete
+			err = os.Remove(licenseDest)
+			if err != nil {
+				util.HandleErrorAndExit(err, "Could not delete existing LICENSE.txt file.")
+			}
+		}
+
+		sourceTxtB, _ := ioutil.ReadFile(licenseSource)
+		if string(sourceTxtB) != string(destTxtB) {
+			util.PrintInfo("Existing license is not WSO2 Update EULA 1.0. This will not be used.")
+			err = os.Remove(licenseDest)
+			if err != nil {
+				util.HandleErrorAndExit(err, "Could not delete existing LICENSE.txt file.")
+			}
+
+			// Write/overwrite LICENSE.txt
+			util.CopyFile(licenseSource, licenseDest)
+			util.PrintInfo(fmt.Sprintf("WSO2 Update EULA 1.0 copied to %v", licenseDest))
+		} else {
+			util.PrintInfo("Existing license is WSO2 Update EULA 1.0. This will be used as is.")
+		}
+	}
+
 	//Print whats next
 	color.Set(color.Bold)
 	fmt.Println("\nWhat's next?")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -195,7 +195,7 @@ func initDirectory(destination string) {
 		absDestination))
 
 	// Check if LICENSE.txt already exists
-	licenseSource, err := os.Getwd()
+	licenseSource, err := filepath.Abs(filepath.Dir(os.Args[0]))
 	if err != nil {
 		util.HandleErrorAndExit(err, "Couldn't get current working directory.")
 	}

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -229,10 +229,20 @@ func readUpdateZip(filename string) (map[string]bool, *util.UpdateDescriptor, er
 				if err != nil {
 					return nil, nil, err
 				}
+
+				// All updates should be licensed to WSO2 Update EULA
 				dataString := string(data)
-				if strings.Contains(dataString, "under Apache License 2.0") {
-					isASecPatch = true
+				eulaPath, err := filepath.Abs(filepath.Dir(os.Args[0]))
+				if err != nil {
+					util.HandleErrorAndExit(err, "Couldn't get current working directory.")
 				}
+
+				eulaPath = filepath.Join(eulaPath, "resources", constant.LICENSE_FILE)
+				eulaText, _ := ioutil.ReadFile(eulaPath)
+				if dataString != string(eulaText) {
+					return nil, nil, errors.New("Update license has been changed from WSO2 Update EULA 1.0.")
+				}
+
 			case constant.INSTRUCTIONS_FILE:
 				_, err := validateFile(file, constant.INSTRUCTIONS_FILE, fullPath, updateName)
 				if err != nil {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -232,15 +232,24 @@ func readUpdateZip(filename string) (map[string]bool, *util.UpdateDescriptor, er
 
 				// All updates should be licensed to WSO2 Update EULA
 				dataString := string(data)
-				eulaPath, err := filepath.Abs(filepath.Dir(os.Args[0]))
+				eulaPath, err := os.Getwd()
 				if err != nil {
 					util.HandleErrorAndExit(err, "Couldn't get current working directory.")
+				}
+
+				if strings.HasSuffix(eulaPath, "bin") {
+					eulaPath = eulaPath[0:len(eulaPath)-len("bin")]
 				}
 
 				eulaPath = filepath.Join(eulaPath, "resources", constant.LICENSE_FILE)
 				eulaText, _ := ioutil.ReadFile(eulaPath)
 				if dataString != string(eulaText) {
-					return nil, nil, errors.New("Update license has been changed from WSO2 Update EULA 1.0.")
+					if strings.Contains(dataString, "under Apache License 2.0") {
+						isASecPatch = true
+						util.PrintInfo("Update license is Apache License 2.0 and not WUM Update EULA 1.0.")
+					} else {
+						util.PrintInfo("Update license is not WUM Update EULA 1.0.")
+					}
 				}
 
 			case constant.INSTRUCTIONS_FILE:
@@ -281,6 +290,7 @@ func readUpdateZip(filename string) (map[string]bool, *util.UpdateDescriptor, er
 			"and remove '%v' file if necessary.", constant.NOT_A_CONTRIBUTION_FILE,
 			constant.NOT_A_CONTRIBUTION_FILE))
 	}
+
 	return fileMap, &updateDescriptor, nil
 }
 

--- a/util/defaultvalues.go
+++ b/util/defaultvalues.go
@@ -22,7 +22,7 @@ var (
 	// want to check md5 if this value is true. By default we want to check. So that's why we have set
 	// CheckMd5Disabled to false here.
 	CheckMd5Disabled        = false
-	ResourceFiles_Mandatory = []string{"update-descriptor.yaml", "LICENSE.txt"}
+	ResourceFiles_Mandatory = []string{"update-descriptor.yaml"}
 	ResourceFiles_Optional  = []string{"instructions.txt", "NOT_A_CONTRIBUTION.txt"}
 	ResourceFiles_Skip      = []string{"README.txt"}
 	PlatformVersions        = map[string]string{

--- a/util/defaultvalues.go
+++ b/util/defaultvalues.go
@@ -22,7 +22,7 @@ var (
 	// want to check md5 if this value is true. By default we want to check. So that's why we have set
 	// CheckMd5Disabled to false here.
 	CheckMd5Disabled        = false
-	ResourceFiles_Mandatory = []string{"update-descriptor.yaml"}
+	ResourceFiles_Mandatory = []string{"update-descriptor.yaml", "LICENSE.txt"}
 	ResourceFiles_Optional  = []string{"instructions.txt", "NOT_A_CONTRIBUTION.txt"}
 	ResourceFiles_Skip      = []string{"README.txt"}
 	PlatformVersions        = map[string]string{


### PR DESCRIPTION
This PR adds the functionality to copy the EULA as the `LICENSE.txt` to the update location when executing the `init` command. If any existing `LICENSE.txt` file is found, it will be overwritten. 

Execution of `validate` command will also check if `LICENSE.txt` had changed during the time between `init` command and `validate` command. If it has, UCT will print a message to inform the user. 

Resolves #9 