### PR TITLE
Fix issue of creating unnecessary directory inside the update zip

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -798,7 +798,14 @@ func readZip(location string) (node, error) {
 
 		// Get the relative path of the file
 		logger.Trace(fmt.Sprintf("file.Name: %s", file.Name))
-		relativePath := strings.TrimPrefix(file.Name, productName + "/")
+
+		var relativePath string
+		if (strings.Contains(file.Name, "/")) {
+			relativePath = strings.SplitN(file.Name, "/", 2)[1]
+		} else {
+			relativePath = file.Name
+		}
+
 		// Replace all \ with /. Otherwise it will cause issues in Windows OS.
 		relativePath = filepath.ToSlash(relativePath)
 		logger.Trace(fmt.Sprintf("relativePath: %s", relativePath))

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -372,7 +372,14 @@ func readDistributionZip(filename string) (map[string]bool, error) {
 	// Iterate through each file/dir found in
 	for _, file := range zipReader.Reader.File {
 		logger.Trace(file.Name)
-		relativePath := strings.TrimPrefix(file.Name, productName+"/")
+
+		var relativePath string
+		if (strings.Contains(file.Name, "/")) {
+			relativePath = strings.SplitN(file.Name, "/", 2)[1]
+		} else {
+			relativePath = file.Name
+		}
+
 		if !file.FileInfo().IsDir() {
 			fileMap[relativePath] = false
 		}


### PR DESCRIPTION
In an updated pack, since the timestamp is added to the name, the name is different from the directory inside the distribution zip. So while creating an update using update-creator-tool, it will add an additional directory to the update zip because of that name difference. This PR will fix that issue.

resolves #21 