### PR TITLE
Refactor check for ".zip"  extension of a given archive to a util function

### DIFF
--- a/constant/constants.go
+++ b/constant/constants.go
@@ -86,4 +86,6 @@ const (
 	JIRA_KEY_DEFAULT     = "ADD_JIRA_KEY_HERE/GITHUB_ISSUE_URL"
 	JIRA_NA              = "N/A"
 	JIRA_SUMMARY_DEFAULT = "ADD_JIRA_SUMMARY_HERE/GITHUB_ISSUE_SUMMARY"
+	DISTRIBUTION         = "Distribution"
+	UPDATE               = "Update"
 )

--- a/util/utils.go
+++ b/util/utils.go
@@ -452,3 +452,13 @@ func ProcessString(data, delimiter string, trimAll bool) string {
 	}
 	return strings.TrimSuffix(allLines, delimiter)
 }
+
+// This function checks whether the given file is a zip file.
+// archiveType 		type of the archive
+// archiveFilePath	path to the archive file
+func IsZipFile(archiveType, archiveFilePath string) {
+	if !strings.HasSuffix(archiveFilePath, ".zip") {
+		HandleErrorAndExit(errors.New(fmt.Sprintf("%s must be a zip file. Entered file '%s' is not a valid zip file" +
+			".", archiveType, archiveFilePath)))
+	}
+}

--- a/util/utils.go
+++ b/util/utils.go
@@ -458,7 +458,7 @@ func ProcessString(data, delimiter string, trimAll bool) string {
 // archiveFilePath	path to the archive file
 func IsZipFile(archiveType, archiveFilePath string) {
 	if !strings.HasSuffix(archiveFilePath, ".zip") {
-		HandleErrorAndExit(errors.New(fmt.Sprintf("%s must be a zip file. Entered file '%s' is not a valid zip file" +
+		HandleErrorAndExit(errors.New(fmt.Sprintf("%s must be a zip file. Entered file '%s' is not a valid zip file"+
 			".", archiveType, archiveFilePath)))
 	}
 }


### PR DESCRIPTION
## Purpose
Resolves #28 #30 

## Goals
Refactor the logic used to check for ".zip" extenstion of a archive to a seperate util function and used it in the `create` and `validate` command.

## Approach
N/A

## User stories
N/A

## Release note
N/A

## Documentation
N/A, not affected to the final outcome of the tool

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
N/A
 - Integration tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for Go
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A