### PR TITLE
Refactor get relative path of a given file to a util function

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -793,16 +793,7 @@ func readZip(location string) (node, error) {
 		// Get the relative path of the file
 		logger.Trace(fmt.Sprintf("file.Name: %s", file.Name))
 
-		var relativePath string
-		if strings.Contains(file.Name, "/") {
-			relativePath = strings.SplitN(file.Name, "/", 2)[1]
-		} else {
-			relativePath = file.Name
-		}
-
-		// Replace all \ with /. Otherwise it will cause issues in Windows OS.
-		relativePath = filepath.ToSlash(relativePath)
-		logger.Trace(fmt.Sprintf("relativePath: %s", relativePath))
+		relativePath := util.GetRelativePath(file)
 
 		// Add the file to root node
 		AddToRootNode(&rootNode, strings.Split(relativePath, "/"), file.FileInfo().IsDir(), md5Hash)

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -367,12 +367,7 @@ func readDistributionZip(filename string) (map[string]bool, error) {
 	for _, file := range zipReader.Reader.File {
 		logger.Trace(file.Name)
 
-		var relativePath string
-		if strings.Contains(file.Name, "/") {
-			relativePath = strings.SplitN(file.Name, "/", 2)[1]
-		} else {
-			relativePath = file.Name
-		}
+		relativePath := util.GetRelativePath(file)
 
 		if !file.FileInfo().IsDir() {
 			fileMap[relativePath] = false

--- a/util/utils.go
+++ b/util/utils.go
@@ -32,6 +32,7 @@ import (
 	"syscall"
 	"time"
 
+	"archive/zip"
 	"github.com/fatih/color"
 	"github.com/ian-kent/go-log/log"
 	"github.com/pkg/errors"
@@ -461,4 +462,16 @@ func IsZipFile(archiveType, archiveFilePath string) {
 		HandleErrorAndExit(errors.New(fmt.Sprintf("%s must be a zip file. Entered file '%s' is not a valid zip file"+
 			".", archiveType, archiveFilePath)))
 	}
+}
+
+// This function will return the relative path of the given file.
+// file	file in which the relative path is to be obtained
+func GetRelativePath(file *zip.File) (relativePath string) {
+	if strings.Contains(file.Name, "/") {
+		relativePath = strings.SplitN(file.Name, "/", 2)[1]
+	} else {
+		relativePath = file.Name
+	}
+	logger.Trace(fmt.Sprintf("relativePath: %s", relativePath))
+	return
 }


### PR DESCRIPTION
## Purpose
To avoid the duplication of logic used in getting the relative path of a given file in `create.go` and `validate.go` Resolves #32 

## Goals
Refactor the logic used to get the relative path of a given file in order to avoid code duplications.

## Approach
Refactor the logic used to get the relative path of a given file to a util function and use it in both `create.go` and `validate.go`.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests 
N/A
 - Integration tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A for Go
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Ubuntu 16.04 (64bit) on Intel Core i7-7600U CPU with 16GB of RAM
 
## Learning
Reading the contents of a zip file without extracting in `go` lang.