### PR TITLE
Add LICENSE.txt content validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,9 @@ If the **UPDATE_LOCATION** contained the update 0001, by running this command, y
 
 #### validation command
 
-After we create a update, we might want to unzip it and add more detail to the **update-descriptor.yaml** like removed files. After we do these changes, we can use this validation command to verify that the file structure of the zip is is the same as the distribution.
+After we create a update, we might want to unzip it and add more detail to the **update-descriptor.yaml** like removed files. After we do these changes, we can use this validation command to verify that the file structure of the zip is is the same as the distribution. 
+
+The `LICENSE_MD5` environment variable should be set to the expected MD5 license checksum in order to validate the LICENSE.txt contents.
 
 ```bash
 wum-uc validate <update_loc> <dist_loc> [<flags>]


### PR DESCRIPTION
## Purpose
This PR contains improvement for validating the content of the LICENSE.txt file in the update zip.
Resolves #36 

## Goals
To provide content validation for the license.

## Approach
Given the MD5 checksum of the expected license, the tool validates MD5 of LICENSE.txt file in the update.

## User stories
The tool must validate EULA license content.

## Release note
Improve license validation using the MD5 checksum.

## Documentation
Provided in the README.md

## Training
NA

## Certification
NA

## Marketing
NA

## Automation tests
NA

## Security checks
NA

## Samples
NA

## Related PRs
NA

## Migrations (if applicable)
NA

## Test environment
Ubuntu 16.04 x64 
 
## Learning
NA