### PR TITLE
Add option to download and validate license from a remote location

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,11 @@ Optional Files -
 1. NOT_A_CONTRIBUTION.txt
 2. instructions.txt
 
-**Note:** You can generate the **update-descriptor.yaml** file using the **init** command as shown in the next section. You need to have the product(which you are creating the update for) distribution locally as well. This is used to compare files and create the proper file structure in the update zip.
+**Note 1:** You can generate the **update-descriptor.yaml** file using the **init** command as shown in the next section. You need to have the product(which you are creating the update for) distribution locally as well. This is used to compare files and create the proper file structure in the update zip.
+
+**Note 2:** If you do not have the correct license, the tool can download when creating the update. In order for the tool to download the license,  please set LICENSE_URL environment variable to the following URL.
+
+    https://staging-cdn-updates.private.wso2.com/wum/update/license/LICENSE.txt
 
 Some samples for the **UPDATE_LOCATION** directory is shown below.
 
@@ -129,7 +133,10 @@ If the **UPDATE_LOCATION** contained the update 0001, by running this command, y
 
 After we create a update, we might want to unzip it and add more detail to the **update-descriptor.yaml** like removed files. After we do these changes, we can use this validation command to verify that the file structure of the zip is is the same as the distribution. 
 
-The `LICENSE_MD5` environment variable should be set to the expected MD5 license checksum in order to validate the LICENSE.txt contents.
+Please set `LICENSE_URL` environment variable to the following URL if you want to validate the LICENSE.txt contents.
+
+    https://staging-cdn-updates.private.wso2.com/wum/update/license/LICENSE.txt
+
 
 ```bash
 wum-uc validate <update_loc> <dist_loc> [<flags>]

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -136,6 +136,28 @@ func createUpdate(updateDirectoryPath, distributionPath string) {
 	}
 	logger.Debug(fmt.Sprintf("Descriptor Exists. Location %s", updateDescriptorPath))
 
+	// 2.1) Check whether the LICENSE.txt file exists and download the license if the LICENSE_URL
+	// environment variable is set.
+	updateLicenseTextPath := path.Join(updateDirectoryPath, constant.LICENSE_FILE)
+	exists, err = util.IsFileExists(updateLicenseTextPath)
+	logger.Debug(fmt.Sprintf("Checking '%s' file in %s", constant.LICENSE_FILE, updateDirectoryPath))
+	util.HandleErrorAndExit(err, fmt.Sprintf("Error occurred while reading the '%v'",
+		constant.LICENSE_FILE))
+	if !exists {
+		licenseUrl := os.Getenv(constant.ENV_LICENSE_URL)
+		logger.Debug(fmt.Sprintf(fmt.Sprintf("'%s' not found at '%s' directory.", constant.LICENSE_FILE,
+			updateDirectoryPath)))
+		if len(licenseUrl) != 0 {
+			logger.Debug(fmt.Sprintf(fmt.Sprintf("Environment varible '%s' is set. Getting file from: %s",
+				constant.ENV_LICENSE_URL, licenseUrl)))
+			err := util.DownloadFile(updateLicenseTextPath, licenseUrl)
+			if err != nil {
+				util.HandleErrorAndExit(err, fmt.Sprintf("Error occurred while getting the file '%v' " +
+					"from: %s.", constant.LICENSE_FILE, licenseUrl))
+			}
+		}
+	}
+
 	//3) Check whether the given distribution exists
 	exists, err = util.IsFileExists(distributionPath)
 	util.HandleErrorAndExit(err, fmt.Sprintf("Error occurred while checking '%s'", distributionPath))

--- a/constant/constants.go
+++ b/constant/constants.go
@@ -88,4 +88,7 @@ const (
 	JIRA_SUMMARY_DEFAULT = "ADD_JIRA_SUMMARY_HERE/GITHUB_ISSUE_SUMMARY"
 	DISTRIBUTION         = "Distribution"
 	UPDATE               = "Update"
+
+	// Environment variable names
+	ENV_LICENSE_URL = "LICENSE_URL"
 )

--- a/util/utils.go
+++ b/util/utils.go
@@ -475,3 +475,49 @@ func GetRelativePath(file *zip.File) (relativePath string) {
 	logger.Trace(fmt.Sprintf("relativePath: %s", relativePath))
 	return
 }
+
+// Download a file from given url to the given location.
+func DownloadFile(file string, url string) error {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	// Check if the response is successful
+	if resp.StatusCode != http.StatusOK {
+		return errors.New(fmt.Sprintf("Could not download the file from: %s", url))
+	}
+	// Create the file
+	out, err := os.Create(file)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	// Write the body to file
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Download the content from given url as a byte array.
+func GetContentFromUrl(url string) ([]byte, error) {
+	// Get the data
+	resp, err := http.Get(url)
+	if err != nil {
+		return []byte{}, err
+	}
+	defer resp.Body.Close()
+	// Check if the response is successful
+	if resp.StatusCode != http.StatusOK {
+		return []byte{}, errors.New(fmt.Sprintf("Could not download the file from: %s", url))
+	}
+	// Read content
+	respBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return []byte{}, err
+	}
+	return respBytes, nil
+}


### PR DESCRIPTION
## Purpose
To get the latest valid license from a remote location so that developers do not need to find and add the latest license manually. Resolves #39

## Goals
To create updates with the valid latest license.

## Approach
Take the LICENSE.txt and MD5 checksum from a remote URL when creating and validating an update.

## User stories
- A user must be able to create an update without adding a valid license.
- A user must be able to validate license content.

## Release note
Add option to download and validate license from a remote location

## Documentation
Added to the README.md

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
N/A

## Related PRs
https://github.com/wso2/update-creator-tool/pull/37

## Migrations (if applicable)
N/A

## Test environment
Ubuntu 16.04 x64
Go 1.8.3
 
## Learning
N/A