### PR TITLE
Fix for md5 hash validation issue

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 target="wum-uc.go"
-version="3.0.0"
+version="3.0.1"
 
 type glide >/dev/null 2>&1 || { echo >&2 "Glide dependency management is needed to build the Update Creator Tool (https://glide.sh/).  Aborting."; exit 1; }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -368,24 +368,27 @@ removedFilesInputLoop:
 		updateDescriptorV3.PartiallyApplicableProducts = append(updateDescriptorV3.PartiallyApplicableProducts, *productChanges)
 	}
 
+	// Generate md5sum for product changes
+	updateDescriptorV3.Md5sum = util.GenerateMd5sumForFileChanges(&updateDescriptorV3)
+
 	// Set values to compatible products slice for displaying purpose
 	var compatibleProducts []string
 	for _, productChange := range updateDescriptorV3.CompatibleProducts {
-		compatibleProducts = append(compatibleProducts, productChange.ProductName)
+		productId := productChange.ProductName + "-" + productChange.ProductVersion
+		compatibleProducts = append(compatibleProducts, productId)
 	}
 	// Set values to partially applicable products slice for displaying purpose
 	var partiallyApplicableProducts []string
 	for _, productChange := range updateDescriptorV3.PartiallyApplicableProducts {
-		partiallyApplicableProducts = append(partiallyApplicableProducts, productChange.ProductName)
+		productId := productChange.ProductName + "-" + productChange.ProductVersion
+		partiallyApplicableProducts = append(partiallyApplicableProducts, productId)
 	}
 	// Set values to notify products slice for displaying purpose
 	var notifyProducts []string
 	for _, partialUpdatedProducts := range partialUpdatedFileResponse.NotifyProducts {
-		notifyProducts = append(notifyProducts, partialUpdatedProducts.ProductName)
+		productId := partialUpdatedProducts.ProductName + "-" + partialUpdatedProducts.BaseVersion
+		notifyProducts = append(notifyProducts, productId)
 	}
-
-	// Generate md5sum for product changes
-	updateDescriptorV3.Md5sum = util.GenerateMd5sumForFileChanges(&updateDescriptorV3)
 
 	//10) Copy resource files (LICENSE.txt, etc) to temp directory
 	resourceFiles := getResourceFiles()

--- a/util/utils.go
+++ b/util/utils.go
@@ -1018,37 +1018,115 @@ func GenerateMd5sumForFileChanges(updateDescriptorV3 *UpdateDescriptorV3) string
 	var modifiedFileString string
 	var removedFileString string
 
-	// Sorting the product changes of update-descriptor3.yaml in ascending order on product names
-	sort.Slice(updateDescriptorV3.CompatibleProducts, func(i, j int) bool {
-		return updateDescriptorV3.CompatibleProducts[i].ProductName < updateDescriptorV3.CompatibleProducts[j].ProductName
+	// Sorting the product changes of update-descriptor3.yaml in ascending order on product names and versions
+	compatibleProductChangesMap := make(map[string]ProductChanges)
+	for _, productChange := range updateDescriptorV3.CompatibleProducts {
+		var buffer bytes.Buffer
+		buffer.WriteString(productChange.ProductName)
+		buffer.WriteString("-")
+		buffer.WriteString(productChange.ProductVersion)
+		compatibleProductChangesMap[buffer.String()] = productChange
+	}
+
+	// Get productIds of compatibleProductChangesMap for sorting
+	var sortedCompatibleProducts []string
+	for productId := range compatibleProductChangesMap {
+		sortedCompatibleProducts = append(sortedCompatibleProducts, productId)
+	}
+
+	// Sorting the compatible products list on product name and version wise
+	sort.Slice(sortedCompatibleProducts, func(i, j int) bool {
+		productId1 := strings.Split(sortedCompatibleProducts[i], "-")
+		productId2 := strings.Split(sortedCompatibleProducts[j], "-")
+		// If product names are different
+		if productId1[0] != productId2[0] {
+			return sortedCompatibleProducts[i] < sortedCompatibleProducts[j]
+		} else {
+			// Product names are same, check for their version when comparing
+			productVersion1 := strings.Split(productId1[1], ".")
+			productVersion2 := strings.Split(productId2[1], ".")
+
+			for k := 0; k < len(productVersion1); k++ {
+				if productVersion1[k] != productVersion2[k] {
+					return sortedCompatibleProducts[i] < sortedCompatibleProducts[j]
+				}
+			}
+		}
+		return sortedCompatibleProducts[i] < sortedCompatibleProducts[j]
 	})
-	sort.Slice(updateDescriptorV3.PartiallyApplicableProducts, func(i, j int) bool {
-		return updateDescriptorV3.PartiallyApplicableProducts[i].ProductName < updateDescriptorV3.PartiallyApplicableProducts[j].
-			ProductName
+	log.Debug("Sorted compatible products list: ", sortedCompatibleProducts)
+
+	partiallyApplicableProductChangesMap := make(map[string]ProductChanges)
+	for _, productChange := range updateDescriptorV3.PartiallyApplicableProducts {
+		var buffer bytes.Buffer
+		buffer.WriteString(productChange.ProductName)
+		buffer.WriteString("-")
+		buffer.WriteString(productChange.ProductVersion)
+		partiallyApplicableProductChangesMap[buffer.String()] = productChange
+	}
+
+	// Get productIds of partiallyApplicableProductChangesMap for sorting
+	var sortedPartialApplicableProducts []string
+	for productId := range partiallyApplicableProductChangesMap {
+		sortedPartialApplicableProducts = append(sortedPartialApplicableProducts, productId)
+	}
+
+	// Sorting the partially applicable products list on product name and version wise
+	sort.Slice(sortedPartialApplicableProducts, func(i, j int) bool {
+		productId1 := strings.Split(sortedPartialApplicableProducts[i], "-")
+		productId2 := strings.Split(sortedPartialApplicableProducts[j], "-")
+		// If product names are different
+		if productId1[0] != productId2[0] {
+			return sortedPartialApplicableProducts[i] < sortedPartialApplicableProducts[j]
+		} else {
+			// Product names are same, check for their version when comparing
+			productVersion1 := strings.Split(productId1[1], ".")
+			productVersion2 := strings.Split(productId2[1], ".")
+
+			for k := 0; k < len(productVersion1); k++ {
+				if productVersion1[k] != productVersion2[k] {
+					return sortedPartialApplicableProducts[i] < sortedPartialApplicableProducts[j]
+				}
+			}
+		}
+		return sortedPartialApplicableProducts[i] < sortedPartialApplicableProducts[j]
 	})
+	log.Debug("Sorted partially applicable products list: ", sortedPartialApplicableProducts)
 
 	// Appending product changes of compatible products to buffer
-	for _, productChange := range updateDescriptorV3.CompatibleProducts {
-		addedFileString = strings.Join(productChange.AddedFiles, ",")
-		modifiedFileString = strings.Join(productChange.ModifiedFiles, ",")
-		removedFileString = strings.Join(productChange.RemovedFiles, ",")
+	var tempCompatibleProducts []ProductChanges
+	for _, productId := range sortedCompatibleProducts {
+		addedFileString = strings.Join(compatibleProductChangesMap[productId].AddedFiles, ",")
+		modifiedFileString = strings.Join(compatibleProductChangesMap[productId].ModifiedFiles, ",")
+		removedFileString = strings.Join(compatibleProductChangesMap[productId].RemovedFiles, ",")
 		buffer.WriteString(addedFileString)
 		buffer.WriteString(modifiedFileString)
 		buffer.WriteString(removedFileString)
-		buffer.WriteString(productChange.ProductName)
-		buffer.WriteString(productChange.ProductVersion)
+		buffer.WriteString(compatibleProductChangesMap[productId].ProductName)
+		buffer.WriteString(compatibleProductChangesMap[productId].ProductVersion)
+		tempCompatibleProducts = append(tempCompatibleProducts, compatibleProductChangesMap[productId])
 	}
+
+	// Replacing compatible products in updateDescriptorV3 with sorted product names and versions
+	updateDescriptorV3.CompatibleProducts = tempCompatibleProducts
+
 	// Appending product changes of partially updated products to buffer
-	for _, productChange := range updateDescriptorV3.PartiallyApplicableProducts {
-		addedFileString = strings.Join(productChange.AddedFiles, ",")
-		modifiedFileString = strings.Join(productChange.ModifiedFiles, ",")
-		removedFileString = strings.Join(productChange.RemovedFiles, ",")
+	var tempPartiallyApplicableProducts []ProductChanges
+	for _, productId := range sortedPartialApplicableProducts {
+		addedFileString = strings.Join(partiallyApplicableProductChangesMap[productId].AddedFiles, ",")
+		modifiedFileString = strings.Join(partiallyApplicableProductChangesMap[productId].ModifiedFiles, ",")
+		removedFileString = strings.Join(partiallyApplicableProductChangesMap[productId].RemovedFiles, ",")
 		buffer.WriteString(addedFileString)
 		buffer.WriteString(modifiedFileString)
 		buffer.WriteString(removedFileString)
-		buffer.WriteString(productChange.ProductName)
-		buffer.WriteString(productChange.ProductVersion)
+		buffer.WriteString(partiallyApplicableProductChangesMap[productId].ProductName)
+		buffer.WriteString(partiallyApplicableProductChangesMap[productId].ProductVersion)
+		tempPartiallyApplicableProducts = append(tempPartiallyApplicableProducts, partiallyApplicableProductChangesMap[productId])
 	}
+
+	// Replacing partially updated products in updateDescriptorV3 with sorted product names and versions
+	updateDescriptorV3.PartiallyApplicableProducts = tempPartiallyApplicableProducts
+
 	return fmt.Sprintf("%x", md5.Sum(buffer.Bytes()))
 }
 


### PR DESCRIPTION
## Purpose
> This PR contains the necessary changes for `MD5SUM` issue occurred due to the sorting of product names and changes needed for displaying relevant product versions with their product names in the summary output of update creation process.
Resolves #57 
Resolves #58 


## Goals
> To generate the `MD5SUM` from product lists sorted on the product name and their respective product version.

## Approach
> Sort the list of compatible and partially applicable products before generating the `MD5SUM` which is used in `wum-uc validate` command.
## User stories
> To generate the `MD5SUM` from product lists sorted on the product name and their respective product version.

## Release note
> N/A

## Documentation
> Changed accordingly

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> Replace the existing binary with the new release `3.0.1`
## Test environment
> `Ubuntu 16.04` with `go 1.9.2`
 
## Learning
> N/A