### PR TITLE
Fix platform version for hamming platform

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -641,8 +641,8 @@ userInputLoop:
 			break userInputLoop
 		case 2:
 			updateDescriptorV2.PlatformName = "hamming"
-			updateDescriptorV2.PlatformVersion = "5.5.0"
-			fmt.Println(fmt.Sprintf("platform name: 'hamming' and platform version: '5.5.0' selected\n"))
+			updateDescriptorV2.PlatformVersion = "5.0.0"
+			fmt.Println(fmt.Sprintf("platform name: 'hamming' and platform version: '5.0.0' selected\n"))
 			break userInputLoop
 		default:
 			util.PrintError("Invalid input")


### PR DESCRIPTION
## Purpose
> Platform version for `hamming` platform should be `5.0.0`, currently the tool uses version `5.5.0` as` hamming` platform. This PR contains necessary changes required 
 Resolves #60 
## Goals
> To enable the creation of updates for `hamming` platform with correct platform version

## Approach
> Change the platform version from `5.5.0` to `5.0.0` for `hamming` platform

## User stories
> To enable the creation of updates for `hamming` platform with correct platform version

## Release note
> N/A
## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A
## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A
## Related PRs
> N/A

## Migrations (if applicable)
> N/A
## Test environment
> `Ubuntu 16.04` with `go 1.8`
 
## Learning
> N/A